### PR TITLE
fix-project-display-bug-update-visualization-file

### DIFF
--- a/src/pages/Visualizations/Visualizations.js
+++ b/src/pages/Visualizations/Visualizations.js
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import files from '../../file2.png';
+import files from '../../files.png';
 import { NoticeBox, Button, FileInputField, DataTable, TableHead, DataTableRow, DataTableColumnHeader, TableBody, DataTableCell } from '@dhis2/ui';
 
 export function Visualizations() {


### PR DESCRIPTION
Previously, users were unable to display the cloned project due to an error that prevented the correct image file from being loaded. After investigating the issue, I discovered that the file name for the image was incorrect in the visualization.js file. Specifically, the file was named "files2.png" instead of "files.png".

To fix the bug, I updated the file name in the visualization.js file to "files.png". This allowed the correct image file to be loaded and displayed, enabling users to view the cloned project as expected.

This commit resolves the bug and ensures that users can now display their cloned projects without any issues.